### PR TITLE
docs: add Advanced Guide pages

### DIFF
--- a/docs/guide/auto-uuid.md
+++ b/docs/guide/auto-uuid.md
@@ -1,0 +1,82 @@
+# Auto-UUID
+
+Automatic UUID4 generation for partition keys and sort keys.
+
+## Basic Usage
+
+```python
+from uuid import UUID
+from dynantic import DynamoModel, Key
+
+class Product(DynamoModel):
+    product_id: UUID = Key(auto=True)  # Auto-generates UUID4
+    name: str
+    price: float
+
+    class Meta:
+        table_name = "products"
+
+# create() — INSERT semantics (fails if PK already exists)
+product = Product.create(name="Widget", price=29.99)
+print(product.product_id)  # UUID('a1b2c3d4-e5f6-...')
+print(type(product.product_id))  # <class 'uuid.UUID'>
+```
+
+## `create()` vs `save()`
+
+| Method | Semantics | Behavior on duplicate |
+|---|---|---|
+| `create()` | INSERT | Raises `ConditionalCheckFailedError` |
+| `save()` | UPSERT | Overwrites existing item |
+
+```python
+# create() adds a condition: Attr(pk).not_exists()
+product = Product.create(name="Widget", price=29.99)
+
+# save() after create() works as upsert
+product.price = 34.99
+product.save()  # Updates existing item
+```
+
+## Explicit UUID Override
+
+```python
+from uuid import UUID
+
+explicit_id = UUID("00000000-0000-4000-8000-000000000001")
+special = Product.create(product_id=explicit_id, name="Promo", price=0.0)
+```
+
+## Composite Key with Auto-UUID
+
+Both partition key and sort key can use `auto=True`:
+
+```python
+from uuid import UUID
+from dynantic import DynamoModel, Key, SortKey
+
+class AuditLog(DynamoModel):
+    log_id: UUID = Key(auto=True)
+    entry_id: UUID = SortKey(auto=True)
+    action: str
+    details: str = ""
+
+    class Meta:
+        table_name = "audit_logs"
+
+log = AuditLog.create(action="USER_LOGIN", details="From 192.168.1.1")
+print(f"pk={log.log_id}, sk={log.entry_id}")
+```
+
+## Works with All Write Paths
+
+UUID is generated at **instantiation time**, so it works with batch operations:
+
+```python
+products = [Product(name=f"Item {i}", price=i * 10.0) for i in range(100)]
+Product.batch_save(products)
+# Each product has a unique UUID assigned at creation
+```
+
+!!! note
+    Auto-UUID uses Python's `uuid4()` — no external dependencies. UUID4 collision probability is negligible (~1 in 2^122).

--- a/docs/guide/batch.md
+++ b/docs/guide/batch.md
@@ -1,0 +1,68 @@
+# Batch Operations
+
+Read and write items in bulk with automatic chunking and exponential backoff retry.
+
+## Batch Save
+
+Save up to thousands of items — auto-chunked into groups of 25.
+
+```python
+users = [
+    User(user_id=f"u{i}", name=f"User {i}", email=f"user{i}@example.com", age=20 + i)
+    for i in range(50)
+]
+User.batch_save(users)
+```
+
+## Batch Get
+
+Fetch multiple items by key — auto-chunked into groups of 100.
+
+```python
+keys = [{"user_id": f"u{i}"} for i in range(50)]
+users = User.batch_get(keys)
+```
+
+!!! warning "Order not guaranteed"
+    DynamoDB does not guarantee order in `batch_get` responses. Sort results after fetching if needed:
+    ```python
+    sorted_users = sorted(users, key=lambda u: u.user_id)
+    ```
+
+## Batch Delete
+
+Delete multiple items by key — auto-chunked into groups of 25.
+
+```python
+User.batch_delete([{"user_id": f"u{i}"} for i in range(50)])
+```
+
+## Batch Writer (Context Manager)
+
+Mix saves and deletes in a single batch context. Auto-flushes every 25 items and on exit.
+
+```python
+with User.batch_writer() as batch:
+    # Add new users
+    for i in range(100, 110):
+        batch.save(
+            User(user_id=f"u{i}", name=f"User {i}", email=f"user{i}@example.com", age=25)
+        )
+
+    # Delete some existing users
+    for i in range(25, 30):
+        batch.delete(user_id=f"u{i}")
+```
+
+## Automatic Retry
+
+All batch operations include **exponential backoff retry** for unprocessed items (up to 5 retries). This handles DynamoDB throttling transparently — no manual retry logic needed.
+
+## Chunk Sizes
+
+| Operation | Chunk Size | DynamoDB Limit |
+|---|---|---|
+| `batch_save()` | 25 | 25 items per BatchWriteItem |
+| `batch_get()` | 100 | 100 keys per BatchGetItem |
+| `batch_delete()` | 25 | 25 items per BatchWriteItem |
+| `batch_writer()` | 25 | Auto-flushes at 25 items |

--- a/docs/guide/conditions.md
+++ b/docs/guide/conditions.md
@@ -1,0 +1,54 @@
+# Conditional Writes
+
+Dynantic provides an SQLModel-like DSL for conditional operations on DynamoDB.
+
+## Basic Conditions
+
+```python
+from dynantic import Attr
+
+# Create-if-not-exists
+user = User(user_id="u1", email="test@example.com")
+user.save(condition=User.email.not_exists())
+
+# Optimistic locking
+user.save(condition=User.version == 5)
+
+# Conditional delete
+User.delete("u1", condition=(User.balance == 0) & (User.status == "inactive"))
+```
+
+## Complex Conditions
+
+```python
+# Combine multiple conditions
+condition = (User.age >= 18) & (User.status == "active") & ~User.is_banned.exists()
+user.save(condition=condition)
+
+# Dynamic field names with Attr()
+User.delete("u1", condition=Attr("legacy_field").not_exists())
+```
+
+## Comparison Operators
+
+| Operator | Example |
+|---|---|
+| `==`, `!=` | `User.status == "active"` |
+| `<`, `<=`, `>`, `>=` | `User.age >= 18` |
+| `.exists()` | `User.email.exists()` |
+| `.not_exists()` | `User.deleted_at.not_exists()` |
+| `.begins_with(prefix)` | `User.name.begins_with("A")` |
+| `.contains(value)` | `User.tags.contains("premium")` |
+| `.between(low, high)` | `User.age.between(18, 65)` |
+| `.is_in([values])` | `User.status.is_in(["active", "pending"])` |
+
+## Logical Operators
+
+| Operator | Meaning | Example |
+|---|---|---|
+| `&` | AND | `(User.age >= 18) & (User.active == True)` |
+| `\|` | OR | `(User.role == "admin") \| (User.role == "super")` |
+| `~` | NOT | `~User.is_banned.exists()` |
+
+!!! tip "Use `Attr()` for mypy compatibility"
+    The metaclass DSL (`User.status == "active"`) works at runtime but mypy doesn't understand it. Use `Attr("status") == "active"` for type-safe code.

--- a/docs/guide/pagination.md
+++ b/docs/guide/pagination.md
@@ -1,0 +1,69 @@
+# Pagination
+
+External pagination lets your API return cursors to clients for stateless pagination.
+
+## Query Pagination
+
+```python
+# Get first page
+page1 = Order.query("customer-456").limit(10).page()
+
+print(f"Items: {len(page1.items)}, Has more: {page1.has_more}")
+
+# Get next page using cursor
+if page1.has_more:
+    page2 = Order.query("customer-456").limit(10).page(start_key=page1.last_evaluated_key)
+```
+
+## Scan Pagination
+
+```python
+# First page
+page1 = Product.scan().limit(25).page()
+
+# Next page
+if page1.has_more:
+    page2 = Product.scan().limit(25).page(start_key=page1.last_evaluated_key)
+```
+
+## PageResult
+
+The `page()` method returns a `PageResult` object:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `items` | `list[Model]` | Items in the current page |
+| `last_evaluated_key` | `dict \| None` | Cursor for the next page |
+| `has_more` | `bool` | Whether more pages exist |
+
+## FastAPI Integration
+
+```python
+from fastapi import FastAPI, Query
+from typing import Any
+from pydantic import BaseModel
+
+app = FastAPI()
+
+class PaginatedResponse(BaseModel):
+    items: list[dict[str, Any]]
+    next_cursor: dict[str, Any] | None
+    has_more: bool
+
+@app.get("/orders/{customer_id}")
+def get_orders(
+    customer_id: str,
+    limit: int = Query(default=20, le=100),
+    cursor: dict[str, Any] | None = None
+) -> PaginatedResponse:
+    page = Order.query(customer_id).limit(limit).page(start_key=cursor)
+
+    return PaginatedResponse(
+        items=[order.model_dump() for order in page.items],
+        next_cursor=page.last_evaluated_key,
+        has_more=page.has_more
+    )
+```
+
+!!! tip "Security"
+    Pagination cursors contain DynamoDB key values. If exposing them to clients, consider encrypting or signing them to prevent tampering.

--- a/docs/guide/polymorphism.md
+++ b/docs/guide/polymorphism.md
@@ -1,0 +1,100 @@
+# Polymorphism (Single-Table Design)
+
+Automatic type discrimination for single-table design patterns.
+
+## Define the Base Model
+
+```python
+from dynantic import DynamoModel, Key, SortKey, Discriminator
+
+class Entity(DynamoModel):
+    pk: str = Key()
+    sk: str = SortKey()
+    entity_type: str = Discriminator()  # Auto-populated with registered value
+
+    class Meta:
+        table_name = "SingleTableExample"
+```
+
+## Register Subclasses
+
+```python
+@Entity.register("CUSTOMER")
+class Customer(Entity):
+    customer_id: str
+    email: str
+    name: str
+    total_orders: int = 0
+
+@Entity.register("ORDER")
+class Order(Entity):
+    order_id: str
+    customer_id: str
+    total_amount: Decimal
+    status: str
+    items: list[dict[str, Any]]
+
+@Entity.register("PRODUCT")
+class Product(Entity):
+    product_id: str
+    name: str
+    price: Decimal
+    category: str
+```
+
+## Usage
+
+```python
+from datetime import datetime, timezone
+from decimal import Decimal
+
+now = datetime.now(timezone.utc)
+
+# Create different entity types in the same table
+customer = Customer(
+    pk="CUSTOMER#cust-001",
+    sk="PROFILE",
+    customer_id="cust-001",
+    email="john@example.com",
+    name="John Doe",
+)
+customer.save()
+
+order = Order(
+    pk="CUSTOMER#cust-001",   # Same PK as customer for efficient querying
+    sk="ORDER#order-001",
+    order_id="order-001",
+    customer_id="cust-001",
+    total_amount=Decimal("199.98"),
+    status="processing",
+    items=[{"product_id": "prod-001", "quantity": 1}],
+)
+order.save()
+```
+
+## Automatic Type Resolution
+
+Queries and scans on the base model return correctly typed instances:
+
+```python
+# Query returns mixed types — each deserialized to its registered class
+items = Entity.query("CUSTOMER#cust-001").all()
+for item in items:
+    if isinstance(item, Customer):
+        print(f"Customer: {item.name}")
+    elif isinstance(item, Order):
+        print(f"Order: {item.order_id} - ${item.total_amount}")
+
+# Scan also returns correct types
+all_entities = list(Entity.scan().limit(10))
+products = [e for e in all_entities if isinstance(e, Product)]
+```
+
+## How It Works
+
+1. The `Discriminator()` field stores the registered type name (e.g., `"CUSTOMER"`, `"ORDER"`)
+2. On save, the discriminator value is **automatically injected** — you don't set it manually
+3. On read, Dynantic uses the discriminator value to deserialize into the correct subclass
+
+!!! tip "Access Pattern Design"
+    Use the same partition key prefix for related entities (e.g., `CUSTOMER#cust-001`) to fetch them in a single query. This is the core benefit of single-table design.

--- a/docs/guide/transactions.md
+++ b/docs/guide/transactions.md
@@ -1,0 +1,76 @@
+# Transactions
+
+**ACID transactions** across one or more DynamoDB tables. All operations succeed or all fail.
+
+## Simple: transact_save
+
+Atomically save multiple items — works across different tables.
+
+```python
+user = User(user_id="u1", name="Alice")
+order = Order(order_id="o1", amount=99.99)
+DynamoModel.transact_save([user, order])
+```
+
+## Advanced: transact_write
+
+Combine Put, Delete, and ConditionCheck operations in a single transaction.
+
+```python
+from dynantic import Attr, TransactPut, TransactDelete, TransactConditionCheck
+
+DynamoModel.transact_write([
+    # Create-if-not-exists
+    TransactPut(user, condition=Attr("user_id").not_exists()),
+    # Delete with condition
+    TransactDelete(Order, condition=Attr("status") == "cancelled", order_id="o1"),
+    # Validate without modifying
+    TransactConditionCheck(Account, Attr("balance") >= 100, account_id="acc-1"),
+])
+```
+
+### Real-World Example: Money Transfer
+
+```python
+from dynantic import Attr, TransactPut
+
+# Transfer $200 from Alice to Bob atomically
+DynamoModel.transact_write([
+    TransactPut(
+        Account(account_id="acc-1", owner="Alice", balance=800.0),
+        condition=(Attr("active") == True) & (Attr("balance") >= 200),
+    ),
+    TransactPut(
+        Account(account_id="acc-2", owner="Bob", balance=700.0),
+    ),
+    TransactPut(transfer),
+])
+```
+
+## Atomic Reads: transact_get
+
+Get a consistent snapshot of multiple items.
+
+```python
+from dynantic import TransactGet
+
+results = DynamoModel.transact_get([
+    TransactGet(User, user_id="u1"),
+    TransactGet(Order, order_id="o1"),
+])
+# results[0] is User | None, results[1] is Order | None
+```
+
+Missing items return `None` — no exceptions.
+
+!!! warning "100-item limit"
+    DynamoDB limits transactions to **100 items** per request. Dynantic validates this and raises `ValidationError` if exceeded.
+
+## Transaction Types
+
+| Type | Description |
+|---|---|
+| `TransactPut(model, condition=...)` | Save an item with optional condition |
+| `TransactDelete(ModelClass, condition=..., **keys)` | Delete by key with optional condition |
+| `TransactConditionCheck(ModelClass, condition, **keys)` | Validate condition without modifying |
+| `TransactGet(ModelClass, **keys)` | Read an item atomically |

--- a/docs/guide/ttl.md
+++ b/docs/guide/ttl.md
@@ -1,0 +1,76 @@
+# TTL (Time To Live)
+
+Automatic datetime-to-epoch conversion for DynamoDB TTL attributes.
+
+## datetime TTL (Recommended)
+
+```python
+from datetime import datetime, timedelta, timezone
+from dynantic import DynamoModel, Key, TTL
+
+class Session(DynamoModel):
+    session_id: str = Key()
+    user_id: str
+    expires_at: datetime = TTL()  # Stored as epoch seconds in DynamoDB
+
+    class Meta:
+        table_name = "sessions"
+
+# Create with datetime — automatically converted to epoch on save
+session = Session(
+    session_id="sess-123",
+    user_id="user-42",
+    expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+)
+session.save()
+
+# Read back — automatically converted from epoch to datetime
+retrieved = Session.get("sess-123")
+print(isinstance(retrieved.expires_at, datetime))  # True
+```
+
+## int TTL (Raw Epoch)
+
+```python
+import time
+from dynantic import DynamoModel, Key, TTL
+
+class CacheEntry(DynamoModel):
+    cache_key: str = Key()
+    value: str
+    ttl: int = TTL()
+
+    class Meta:
+        table_name = "cache"
+
+entry = CacheEntry(
+    cache_key="api:/users/42",
+    value='{"name": "John"}',
+    ttl=int(time.time()) + 3600,  # Expires in 1 hour
+)
+entry.save()
+```
+
+## Works with All Write Paths
+
+TTL serialization is handled automatically across all write operations:
+
+- `save()`
+- `batch_save()`
+- `batch_writer()`
+- `transact_save()`
+- `transact_write()`
+
+!!! warning "Table-level TTL setup required"
+    TTL must also be enabled on the DynamoDB table itself. Dynantic only handles the field serialization.
+
+    ```hcl
+    # Terraform example
+    resource "aws_dynamodb_table" "sessions" {
+      # ...
+      ttl {
+        attribute_name = "expires_at"
+        enabled        = true
+      }
+    }
+    ```

--- a/docs/guide/updates.md
+++ b/docs/guide/updates.md
@@ -1,0 +1,61 @@
+# Atomic Updates
+
+Update DynamoDB items **without fetching them first** — saves read capacity and ensures atomicity.
+
+## Basic Usage
+
+```python
+# Atomic counter increment
+User.update("user-123", "john@example.com") \
+    .add(User.login_count, 1) \
+    .execute()
+
+# Multiple actions in one request
+User.update("user-123", "john@example.com") \
+    .set(User.status, "active") \
+    .add(User.balance, 10.50) \
+    .add(User.tags, {"verified"}) \
+    .remove(User.temporary_code) \
+    .execute()
+```
+
+## Conditional Updates
+
+```python
+User.update("user-123", "john@example.com") \
+    .set(User.status, "inactive") \
+    .condition(User.balance < 0) \
+    .execute()
+```
+
+Raises `ConditionalCheckFailedError` if the condition is not met.
+
+## Delete Elements from a Set
+
+```python
+User.update("user-123", "john@example.com") \
+    .delete(User.permissions, {"admin_access"}) \
+    .execute()
+```
+
+## Return Modified Attributes
+
+```python
+updated_user = User.update("user-123", "john@example.com") \
+    .add(User.login_count, 1) \
+    .return_values("ALL_NEW") \
+    .execute()
+```
+
+**Return value options:** `"ALL_NEW"`, `"ALL_OLD"`, `"UPDATED_NEW"`, `"UPDATED_OLD"`, `"NONE"`
+
+## Supported Actions
+
+| Action | Description | Example |
+|---|---|---|
+| `set(field, value)` | Update an attribute | `.set(User.status, "active")` |
+| `remove(field)` | Remove an attribute | `.remove(User.temp_code)` |
+| `add(field, value)` | Increment number or add to set | `.add(User.balance, 10.0)` |
+| `delete(field, value)` | Remove elements from set | `.delete(User.tags, {"old"})` |
+| `condition(expr)` | Apply conditional expression | `.condition(User.balance > 0)` |
+| `return_values(opt)` | Control what's returned | `.return_values("ALL_NEW")` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,3 +71,12 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Guide:
+    - Atomic Updates: guide/updates.md
+    - Conditional Writes: guide/conditions.md
+    - Batch Operations: guide/batch.md
+    - Transactions: guide/transactions.md
+    - Pagination: guide/pagination.md
+    - TTL: guide/ttl.md
+    - Auto-UUID: guide/auto-uuid.md
+    - Polymorphism: guide/polymorphism.md


### PR DESCRIPTION
## Summary

- Add 8 guide pages: Atomic Updates, Conditional Writes, Batch Operations, Transactions, Pagination, TTL, Auto-UUID, Polymorphism
- Each page includes working code examples from the `examples/` directory
- Admonitions for warnings (transaction limits, TTL table setup, batch order)

Closes #19

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [ ] CI docs job passes