### PR TITLE
docs: add Integration pages and Comparison

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,57 @@
+# Comparison with Alternatives
+
+## Feature Matrix
+
+| Feature | **Dynantic** | **PynamoDB** | **Raw boto3** |
+|---|:---:|:---:|:---:|
+| Type Safety | Pydantic v2 | Custom types | Dict-based |
+| IDE Autocomplete | Excellent | Good | Limited |
+| Query DSL | Pythonic | Pythonic | Dict-based |
+| Batch Operations | Yes | Yes | Yes |
+| Transactions | Yes | Yes | Yes |
+| TTL Support | Auto-convert | Yes | Manual |
+| Polymorphism | Yes | No | No |
+| Auto-UUID | Yes | No | No |
+| Async Support | No (use threadpool) | No | No (use aioboto3) |
+| Maturity | Beta | Stable | AWS Official |
+
+## When to Use Dynantic
+
+- You use **Pydantic** and want DynamoDB integration
+- You're building **Lambda functions** or sync applications
+- You want **IDE autocomplete** with Pydantic validation
+- You need **single-table design** with polymorphism
+- You value **developer experience** and clean DSL
+
+## When to Use PynamoDB
+
+- You want a **mature, battle-tested** library
+- You prefer a custom type system over Pydantic
+- You don't need Pydantic's validation features
+
+## When to Use Raw boto3
+
+- You need **maximum control** and flexibility
+- You have simple use cases with few models
+- You want AWS's official SDK with guaranteed compatibility
+
+## When to Use aioboto3
+
+- You need **native async/await** support
+- You're building async applications (aiohttp, FastAPI with async endpoints)
+- You're willing to manage async client lifecycle
+
+## Limitations
+
+| Feature | Status | Notes |
+|---|---|---|
+| Async support | Not planned | Use `asyncio.to_thread()` or aioboto3 |
+| Streams | Not planned | Use AWS Lambda triggers |
+| PartiQL | Not planned | Use standard query API |
+| Auto-migrations | Not planned | Manage tables with IaC (Terraform, CDK) |
+
+### Design Constraints
+
+- **No relationships** — DynamoDB doesn't support joins
+- **No schema enforcement** — DynamoDB is schemaless (Pydantic validates on read/write)
+- **Cursor opacity** — Pagination cursors are plain dicts (not cryptographically signed)

--- a/docs/integration/configuration.md
+++ b/docs/integration/configuration.md
@@ -1,0 +1,143 @@
+# Configuration
+
+## AWS Credentials
+
+Dynantic uses boto3, so it follows the standard AWS credential resolution:
+
+1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
+2. Shared credentials file (`~/.aws/credentials`)
+3. AWS config file (`~/.aws/config`)
+4. IAM role (EC2, Lambda, ECS)
+
+```bash
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_DEFAULT_REGION="us-east-1"
+```
+
+## Client Lifecycle
+
+### Global Singleton (Lambda, Scripts)
+
+```python
+import boto3
+from dynantic import DynamoModel
+
+# Create once at module level
+client = boto3.client("dynamodb")
+DynamoModel.set_client(client)
+```
+
+### Per-Request Clients (Multi-Tenant)
+
+```python
+from dynantic import DynamoModel
+
+with User.using_client(tenant_specific_client):
+    user = User.get("user-123")
+```
+
+## Retry Configuration
+
+```python
+from botocore.config import Config
+import boto3
+
+config = Config(
+    retries={
+        "max_attempts": 10,   # Default: 3
+        "mode": "adaptive"    # or "standard", "legacy"
+    },
+    connect_timeout=5,
+    read_timeout=10
+)
+
+client = boto3.client("dynamodb", config=config)
+DynamoModel.set_client(client)
+```
+
+**Retry modes:**
+
+| Mode | Description |
+|---|---|
+| `standard` | Fixed delays with exponential backoff |
+| `adaptive` | Adjusts retry rate based on throttling |
+| `legacy` | Old boto behavior (not recommended) |
+
+## Connection Pooling
+
+```python
+config = Config(max_pool_connections=50)  # Default: 10
+client = boto3.client("dynamodb", config=config)
+```
+
+## Testing with Mocks
+
+```python
+import pytest
+from unittest.mock import MagicMock
+
+@pytest.fixture
+def mock_dynamo_client():
+    client = MagicMock()
+    client.get_item.return_value = {
+        "Item": {
+            "user_id": {"S": "test-123"},
+            "email": {"S": "test@example.com"}
+        }
+    }
+    return client
+
+def test_user_get(mock_dynamo_client):
+    User.set_client(mock_dynamo_client)
+    user = User.get("test-123")
+    assert user.user_id == "test-123"
+    mock_dynamo_client.get_item.assert_called_once()
+```
+
+## Security
+
+### Pagination Cursors
+
+Cursors are unencrypted dicts — always re-apply authorization server-side:
+
+```python
+# Always filter by authenticated user
+@app.get("/orders")
+def get_orders(current_user: User, cursor: dict | None = None):
+    return Order.query(current_user.user_id).page(start_key=cursor)
+```
+
+### Conditional Expressions
+
+Never pass raw user input to `Attr()`:
+
+```python
+# Bad
+condition = Attr(request.query_params["field"]).exists()
+
+# Good — use model fields
+condition = User.email.exists()
+```
+
+### IAM Minimum Permissions
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "dynamodb:GetItem",
+    "dynamodb:PutItem",
+    "dynamodb:UpdateItem",
+    "dynamodb:DeleteItem",
+    "dynamodb:Query",
+    "dynamodb:Scan",
+    "dynamodb:BatchGetItem",
+    "dynamodb:BatchWriteItem"
+  ],
+  "Resource": [
+    "arn:aws:dynamodb:*:*:table/your-table",
+    "arn:aws:dynamodb:*:*:table/your-table/index/*"
+  ]
+}
+```

--- a/docs/integration/fastapi.md
+++ b/docs/integration/fastapi.md
@@ -1,0 +1,112 @@
+# FastAPI Integration
+
+Dynantic models extend Pydantic `BaseModel`, so they work natively with FastAPI.
+
+## Basic CRUD API
+
+```python
+from datetime import datetime, timezone
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel, EmailStr
+from dynantic import DynamoModel, Key
+
+class User(DynamoModel):
+    user_id: str = Key()
+    email: EmailStr
+    name: str
+    age: int
+    bio: str | None = None
+    is_active: bool = True
+    created_at: datetime
+    updated_at: datetime
+
+    class Meta:
+        table_name = "Users"
+
+class UserCreate(BaseModel):
+    user_id: str
+    email: EmailStr
+    name: str
+    age: int
+    bio: str | None = None
+
+app = FastAPI()
+
+@app.post("/users", response_model=User, status_code=status.HTTP_201_CREATED)
+def create_user(user_data: UserCreate) -> User:
+    now = datetime.now(timezone.utc)
+    user = User(
+        **user_data.model_dump(),
+        created_at=now,
+        updated_at=now,
+    )
+    user.save()
+    return user
+
+@app.get("/users/{user_id}", response_model=User)
+def get_user(user_id: str) -> User:
+    user = User.get(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+@app.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_user(user_id: str) -> None:
+    user = User.get(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    User.delete(user_id)
+```
+
+## Async with Thread Pool
+
+Dynantic is **sync-first**. For async FastAPI endpoints, use `asyncio.to_thread()`:
+
+```python
+import asyncio
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/users/{user_id}")
+async def get_user(user_id: str):
+    return await asyncio.to_thread(User.get, user_id)
+
+@app.post("/users")
+async def create_user(user_data: dict):
+    user = User(**user_data)
+    await asyncio.to_thread(user.save)
+    return user.model_dump()
+```
+
+!!! info "Why not native async?"
+    1. **Cold start overhead** — async runtimes have higher initialization cost
+    2. **Lambda fit** — AWS Lambda is optimized for sync request/response
+    3. **Simplicity** — most DynamoDB operations don't benefit from concurrency
+
+## Paginated Responses
+
+```python
+from typing import Any
+from pydantic import BaseModel
+from fastapi import Query
+
+class PaginatedResponse(BaseModel):
+    items: list[dict[str, Any]]
+    next_cursor: dict[str, Any] | None
+    has_more: bool
+
+@app.get("/orders/{customer_id}")
+def get_orders(
+    customer_id: str,
+    limit: int = Query(default=20, le=100),
+    cursor: dict[str, Any] | None = None
+) -> PaginatedResponse:
+    page = Order.query(customer_id).limit(limit).page(start_key=cursor)
+
+    return PaginatedResponse(
+        items=[order.model_dump() for order in page.items],
+        next_cursor=page.last_evaluated_key,
+        has_more=page.has_more
+    )
+```

--- a/docs/integration/localstack.md
+++ b/docs/integration/localstack.md
@@ -1,0 +1,101 @@
+# LocalStack Testing
+
+Run integration tests against a local DynamoDB using LocalStack.
+
+## docker-compose.yaml
+
+```yaml
+version: '3.8'
+services:
+  localstack:
+    image: localstack/localstack:3.0
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=dynamodb
+      - DEBUG=1
+      - DATA_DIR=/tmp/localstack/data
+    volumes:
+      - "/tmp/localstack:/tmp/localstack"
+```
+
+```bash
+docker compose up -d
+```
+
+## Configure Dynantic Client
+
+```python
+import boto3
+from dynantic import DynamoModel
+
+client = boto3.client(
+    "dynamodb",
+    endpoint_url="http://localhost:4566",
+    region_name="us-east-1",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+DynamoModel.set_client(client)
+```
+
+## Pytest Setup
+
+```python
+import boto3
+import pytest
+import os
+
+@pytest.fixture(scope="session", autouse=True)
+def localstack_setup():
+    os.environ["AWS_ENDPOINT_URL"] = "http://localhost:4566"
+    os.environ["AWS_ACCESS_KEY_ID"] = "test"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "test"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+@pytest.fixture
+def dynamo_client():
+    return boto3.client("dynamodb", endpoint_url="http://localhost:4566")
+
+@pytest.fixture
+def create_test_table(dynamo_client):
+    dynamo_client.create_table(
+        TableName="users",
+        KeySchema=[
+            {"AttributeName": "user_id", "KeyType": "HASH"},
+            {"AttributeName": "email", "KeyType": "RANGE"}
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "user_id", "AttributeType": "S"},
+            {"AttributeName": "email", "AttributeType": "S"}
+        ],
+        BillingMode="PAY_PER_REQUEST"
+    )
+    yield
+    dynamo_client.delete_table(TableName="users")
+```
+
+## CI with GitHub Actions
+
+The CI workflow runs integration tests against LocalStack as a service container:
+
+```yaml
+services:
+  localstack:
+    image: localstack/localstack:3.0
+    ports:
+      - 4566:4566
+    env:
+      SERVICES: dynamodb
+    options: >-
+      --health-cmd "curl http://localhost:4566/_localstack/health"
+      --health-interval 10s
+      --health-timeout 5s
+      --health-retries 5
+```
+
+!!! tip "Health check"
+    Always wait for LocalStack to be ready before running tests:
+    ```bash
+    timeout 120 bash -c 'until curl -f http://localhost:4566/_localstack/health; do sleep 5; done'
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,3 +71,8 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Integration:
+    - FastAPI: integration/fastapi.md
+    - Configuration: integration/configuration.md
+    - LocalStack Testing: integration/localstack.md
+  - Comparison: comparison.md


### PR DESCRIPTION
## Summary

- Add `integration/fastapi.md` — CRUD API, async threadpool, paginated responses
- Add `integration/configuration.md` — client lifecycle, retries, connection pooling, security, IAM
- Add `integration/localstack.md` — docker-compose, pytest setup, CI config
- Add `comparison.md` — feature matrix vs PynamoDB/boto3, when-to-use guide

Closes #20

## Test plan

- [x] `uv run mkdocs build --strict` passes
- [ ] CI docs job passes